### PR TITLE
Updating project repository link in For Developers section

### DIFF
--- a/contribute/index.html
+++ b/contribute/index.html
@@ -76,7 +76,7 @@
                 Even if it's something as simple as a typo, let us know!</p>
               <p>If you have a resource you would like to add, the approach is pretty straight forward! Once you're all set up and ready to submit a
                 <a href="https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request" target="_blank">pull request</a> 
-                to the <a href="https://github.com/emmy-html/pbl" target="_blank">project repository</a>, follow along with these instructions.
+                to the <a href="https://github.com/protectblacklives/go" target="_blank">project repository</a>, follow along with these instructions.
               </p>
               <ol>
                 <li>Grab the link to the resource you want to add. Make sure this is a direct link to your content.</li>


### PR DESCRIPTION
The old `project repository` link in the For Developers section was outdated I think (returned a GitHub 404 page). I updated it to the current repository location :seedling: 